### PR TITLE
Removed Severity Redundance

### DIFF
--- a/scripts/travel-roll.js
+++ b/scripts/travel-roll.js
@@ -472,26 +472,26 @@ async function generateDanger(selectedDifficulty, groupLevel, dangerSeverity) {
 
   let result = ""; // Changed to directly append the danger result
 
-  switch (threatType) {
-    case "Damage":
-      result += handleDamage(dataLoader.threatsData, groupLevel, severity);
-      break;
-    case "statusEffect":
-      result += handleStatusEffect(dataLoader.threatsData, severity, groupLevel);
-      break;
-    case "Combat":
-      result += dataLoader.threatsData.Combat[severity];
-      break;
-    case "dangerClock":
-      result += dataLoader.threatsData.dangerClock[severity];
-      break;
-    case "villainPlanAdvance":
-      result += dataLoader.threatsData.villainPlanAdvance[severity];
-      break;
-    default:
-      console.error("Unknown threat type:", threatType);
-      return "Error: Unknown threat type.";
-  }
+switch (threatType) {
+  case "Damage":
+    result += handleDamage(dataLoader.threatsData, groupLevel, dangerSeverity);
+    break;
+  case "statusEffect":
+    result += handleStatusEffect(dataLoader.threatsData, dangerSeverity, groupLevel);
+    break;
+  case "Combat":
+    result += dataLoader.threatsData.Combat[dangerSeverity];
+    break;
+  case "dangerClock":
+    result += dataLoader.threatsData.dangerClock[dangerSeverity];
+    break;
+  case "villainPlanAdvance":
+    result += dataLoader.threatsData.villainPlanAdvance[dangerSeverity];
+    break;
+  default:
+    console.error("Unknown threat type:", threatType);
+    return "Error: Unknown threat type.";
+}
 
   // Return formatted table for danger results and source.
   return `
@@ -508,38 +508,35 @@ async function generateDanger(selectedDifficulty, groupLevel, dangerSeverity) {
   `;
 }
 
-function handleDamage(threatsData, groupLevel, severity) {
+function handleDamage(threatsData, groupLevel, dangerSeverity) {
   const damageData = threatsData.Damage ? threatsData.Damage[groupLevel] : undefined;
 
-  if (!damageData || !damageData[severity]) {
-    console.error(`Damage data not found for groupLevel: ${groupLevel}, severity: ${severity}`);
+  if (!damageData || !damageData[dangerSeverity]) {
+    console.error(`Damage data not found for groupLevel: ${groupLevel}, severity: ${dangerSeverity}`);
     return "Error: Damage data not found.";
   }
-  return `${damageData[severity]} damage`;
+  return `${damageData[dangerSeverity]} damage`;
 }
 
-function handleStatusEffect(threatsData, severity, groupLevel) {
+function handleStatusEffect(threatsData, dangerSeverity, groupLevel) {
   const statusEffectsListMinor = threatsData.statusEffects["Minor"];
   const statusEffectsListHeavy = threatsData.statusEffects["Heavy"];
 
-  if (severity === "Massive") {
+  if (dangerSeverity === "Massive") {
     // 50% chance to pull either a Minor status effect with Heavy damage or a Heavy status effect with Minor damage
     const useMinorEffect = Math.random() < 0.5;
 
     if (useMinorEffect) {
-      // Pick a Minor status effect with Heavy damage
       const statusEffect = getRandomElement(statusEffectsListMinor);
       const heavyDamage = threatsData.Damage[groupLevel]["Heavy"];
       return `${statusEffect} and ${heavyDamage} damage`;
     } else {
-      // Pick a Heavy status effect with Minor damage
       const statusEffect = getRandomElement(statusEffectsListHeavy);
       const minorDamage = threatsData.Damage[groupLevel]["Minor"];
       return `${statusEffect} and ${minorDamage} damage`;
     }
   } else {
-    // Regular logic for Minor and Heavy severities
-    const statusEffectsList = threatsData.statusEffects[severity];
+    const statusEffectsList = threatsData.statusEffects[dangerSeverity];
     return getRandomElement(statusEffectsList);
   }
 }

--- a/scripts/travel-roll.js
+++ b/scripts/travel-roll.js
@@ -352,11 +352,11 @@ await roll.render().then((rollHTML) => {
 
 let resultMessage = "";
 let discoveryType = shouldMakeDiscovery(roll.total);  
-let dangerSeverity = ""; // Variable to store severity
+let dangerSeverity = ""; // Variable to store danger severity
 
 if (roll.total >= 6) {
   dangerSeverity = await randomSeverity(selectedDifficulty);
-  resultMessage = `${dangerSeverity} Danger! ` + await generateDanger(selectedDifficulty, groupLevel);
+  resultMessage = `${dangerSeverity} Danger! ` + await generateDanger(selectedDifficulty, groupLevel, dangerSeverity);
 } else if (discoveryType) {
   resultMessage = discoveryType === "major"
     ? "Major Discovery! " + await generateDiscovery("major")
@@ -404,10 +404,9 @@ function showRerollDialog(initialResult, selectedDifficulty, groupLevel, dangerS
   callback: async () => {
     let newResultMessage;
     if (isDanger) {
-      const dangerSeverity = await randomSeverity(selectedDifficulty);
-      const newDangerResult = await generateDanger(selectedDifficulty, groupLevel);
-      newResultMessage = `${dangerSeverity} Danger! ` + newDangerResult;
-    } else if (discoveryType) {
+  const newDangerResult = await generateDanger(selectedDifficulty, groupLevel, dangerSeverity);
+  newResultMessage = `${dangerSeverity} Danger! ` + newDangerResult;
+} else if (discoveryType) {
       // Pass the discoveryType when generating the new discovery
       const newDiscoveryResult = await generateDiscovery(discoveryType);
       newResultMessage = discoveryType === "major"
@@ -434,13 +433,12 @@ function toReadableText(str) {
     .join(" ");
 }
 
-async function generateDanger(selectedDifficulty, groupLevel) {
+async function generateDanger(selectedDifficulty, groupLevel, dangerSeverity) {
   if (!dataLoader.threatsData || !dataLoader.threatsData.statusEffects) {
     console.error("Threats data is not fully loaded.");
     return "Error: Data not available.";
   }
 
-  const severity = randomSeverity(selectedDifficulty);
   const threatType = randomThreatType();
   const readableThreatType = toReadableText(threatType);
 

--- a/scripts/travel-roll.js
+++ b/scripts/travel-roll.js
@@ -364,10 +364,10 @@ if (roll.total >= 6) {
 } else {
   resultMessage = "The travel day passed without incident.";
 }
-  showRerollDialog(resultMessage, selectedDifficulty, groupLevel, discoveryType);
+  showRerollDialog(resultMessage, selectedDifficulty, groupLevel, dangerSeverity, discoveryType);
 }
 
-function showRerollDialog(initialResult, selectedDifficulty, groupLevel, discoveryType) {
+function showRerollDialog(initialResult, selectedDifficulty, groupLevel, dangerSeverity, discoveryType) {
   let isDanger = initialResult.includes("Danger!");
   let title = isDanger ? "Confirm Danger Result" : "Confirm Discovery Result";
 
@@ -417,7 +417,7 @@ function showRerollDialog(initialResult, selectedDifficulty, groupLevel, discove
       const newDiscoveryResult = await generateDiscovery("major");
       newResultMessage = "Discovery! " + newDiscoveryResult;
     }
-    showRerollDialog(newResultMessage, selectedDifficulty, groupLevel, discoveryType);
+    showRerollDialog(newResultMessage, selectedDifficulty, groupLevel, dangerSeverity, discoveryType);
   },
 },
     },


### PR DESCRIPTION
When working on changing how the severity logic worked, I created a new const for dangerSeverity in order to hold severity variables with the new calculations. This existed outside the generateDanger which was causing the script to generate severity twice.

Visually this wasn't noticeable, as the old severity const was overriding mine in the danger generation. HOWEVER, when I attempted to update the labels for my dialog, it was referencing two instances of danger severity and giving me mixed results.

This was an oversight and is now resolved by consolidating the old codes severity with my new dangerSeverity for clearer identification on what it is.