### PR TITLE
Added Result Visibility Setting 

### DIFF
--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -1,7 +1,7 @@
 export const LookfarSettings = {
   registerSettings() {
     
-game.settings.register("lookfar", "rollVisibility", {
+game.settings.register("lookfar", "resultVisibility", {
   name: "Result Visibility",  // <— updated name
   hint: "Choose whether results and chat outputs are public or GM only.",  // <— optional update
   scope: "world",

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -2,16 +2,16 @@ export const LookfarSettings = {
   registerSettings() {
     
 game.settings.register("lookfar", "rollVisibility", {
-  name: "Roll Visibility",
-  hint: "Choose whether rolls and chat outputs are public or GM only.",
+  name: "Result Visibility",  // <— updated name
+  hint: "Choose whether results and chat outputs are public or GM only.",  // <— optional update
   scope: "world",
   config: true,
   type: String,
   choices: {
-      public: "Public",
-      gmOnly: "GM Only",
-      },
-      default: "public",
+    public: "Public",
+    gmOnly: "GM Only",
+  },
+  default: "public",
 });
 
 game.settings.register("lookfar", "enableKeywords", {

--- a/scripts/travelRoll.js
+++ b/scripts/travelRoll.js
@@ -297,7 +297,11 @@ async function handleRoll(selectedDifficulty, html) {
     dangerSeverity,
   });
 
-  // Show the dialog on the initiating client (for local confirmation)
+const visibility = game.settings.get("lookfar", "resultVisibility");
+const isGM = game.user.isGM;
+
+// Show dialog locally only if it's public, or this user is a GM
+if (visibility === "public" || isGM) {
   showRerollDialog(resultMessage, selectedDifficulty, groupLevel, dangerSeverity);
 }
 

--- a/scripts/travelRoll.js
+++ b/scripts/travelRoll.js
@@ -22,6 +22,12 @@ function generateUniqueList(list, minCount, maxCount) {
 Hooks.once("ready", () => {
   game.socket.on("module.lookfar", (data) => {
     if (data?.type === "showResult") {
+      const visibility = game.settings.get("lookfar", "resultVisibility"); // still using old key internally
+      const isGM = game.user.isGM;
+
+      // Show only to GM if setting is "gmOnly"
+      if (visibility === "gmOnly" && !isGM) return;
+
       showRerollDialog(
         data.resultMessage,
         data.selectedDifficulty,

--- a/scripts/travelRoll.js
+++ b/scripts/travelRoll.js
@@ -304,6 +304,7 @@ const isGM = game.user.isGM;
 if (visibility === "public" || isGM) {
   showRerollDialog(resultMessage, selectedDifficulty, groupLevel, dangerSeverity);
 }
+}
 
 // Keep a reference to the current dialog
 let currentDialog = null;


### PR DESCRIPTION
GM's can set result visibility now. When it is set to "Public", all players can see the result. "GM Only", results are rendered to the GM Only, regardless of who rolls.